### PR TITLE
Fix: Keyboard is not displayed when focussing an webcomponent text field

### DIFF
--- a/content/keyboard/contentScript.js
+++ b/content/keyboard/contentScript.js
@@ -463,15 +463,26 @@ function autoToggleKeyboard() {
     if(isMouseDown) {
         return
     }
+
+    console.log(document.activeElement.shadowRoot?.activeElement ?? "nichts");
+
     if(document.activeElement.matches(querySelector)) {
         if (inputElement === document.activeElement) {
             return
         }
+
         onFocus(document.activeElement)
+    } else if(document.activeElement.shadowRoot?.activeElement.matches(querySelector)) {
+        if (inputElement === document.activeElement.shadowRoot.activeElement){
+            return
+        }
+
+        onFocus(document.activeElement.shadowRoot.activeElement)
     } else {
         if (inputElement === null) {
             return;
         }
+
         onFocusOut()
     }
 }

--- a/content/keyboard/contentScript.js
+++ b/content/keyboard/contentScript.js
@@ -463,9 +463,7 @@ function autoToggleKeyboard() {
     if(isMouseDown) {
         return
     }
-
-    console.log(document.activeElement.shadowRoot?.activeElement ?? "nichts");
-
+    
     if(document.activeElement.matches(querySelector)) {
         if (inputElement === document.activeElement) {
             return


### PR DESCRIPTION
When clicking a text field which is implemented as web component `(input will be rendered in the shadow DOM)` the keyboard does not pop up.
This problem occurs because the application checks the inputs in the `Light DOM` and not in the `Shadow DOM`.

## Changes:

-    If no input field is found in `Light Dom` the extension checks if the current active element has an `Shadow DOM`
-    If it has an Shadow Dom, we check if the active Element in the `Shadow DOM` is an input field
-    For this checks I use the same selector as for the checks in the `Light DOM `

  
Fixes: #10

I hope i can help this project with my contribution 😄 

 